### PR TITLE
Fix release-drafter config for v7

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 
-_extends: .github
+_extends: jenkinsci/.github:.github/release-drafter.yml
 tag-template: memory-monitor-$NEXT_MINOR_VERSION


### PR DESCRIPTION
## Fix release drafter configuration for v7

Release drafter v7 no longer accepts .github as a valid extension.

The [release drafter configuration loading documentation](https://github.com/release-drafter/release-drafter/blob/master/docs/configuration-loading.md) provides an example that uses this syntax for config-name and says that the _extends syntax accepts the same form.  

### Testing done

None.  I don't understand how to test a GitHub action before it is merged to the main branch.  Using it on this low risk repository.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
